### PR TITLE
Refactor: adopt shared PreviewGameData across previews

### DIFF
--- a/PickleballGameTrackerPackage/Sources/GameTrackerFeature/Features/ActiveGame/Components/TimerCard.swift
+++ b/PickleballGameTrackerPackage/Sources/GameTrackerFeature/Features/ActiveGame/Components/TimerCard.swift
@@ -107,10 +107,7 @@ struct TimerCard: View {
 
 #Preview {
   TimerCard(
-    game: {
-      let game = Game(gameType: .recreational)
-      return game
-    }(),
+    game: PreviewGameData.earlyGame,
     formattedElapsedTime: "02:05.67",
     isTimerPaused: false,
     isGameActive: true,
@@ -123,14 +120,12 @@ struct TimerCard: View {
     onToggleTimer: {}
   )
   .padding()
+  .modelContainer(try! PreviewGameData.createPreviewContainer(with: [PreviewGameData.earlyGame]))
 }
 
 #Preview("Timer Paused") {
   TimerCard(
-    game: {
-      let game = Game(gameType: .training)
-      return game
-    }(),
+    game: PreviewGameData.trainingGame,
     formattedElapsedTime: "01:07.23",
     isTimerPaused: true,
     isGameActive: true,
@@ -143,14 +138,12 @@ struct TimerCard: View {
     onToggleTimer: {}
   )
   .padding()
+  .modelContainer(try! PreviewGameData.createPreviewContainer(with: [PreviewGameData.trainingGame]))
 }
 
 #Preview("Game Paused") {
   TimerCard(
-    game: {
-      let game = Game(gameType: .training)
-      return game
-    }(),
+    game: PreviewGameData.pausedGame,
     formattedElapsedTime: "01:07.23",
     isTimerPaused: true,
     isGameActive: false,
@@ -163,17 +156,12 @@ struct TimerCard: View {
     onToggleTimer: {}
   )
   .padding()
+  .modelContainer(try! PreviewGameData.createPreviewContainer(with: [PreviewGameData.pausedGame]))
 }
 
 #Preview("Game Completed") {
   TimerCard(
-    game: {
-      let game = Game(gameType: .recreational)
-      game.score1 = 11
-      game.score2 = 7
-      game.completeGame()
-      return game
-    }(),
+    game: PreviewGameData.completedGame,
     formattedElapsedTime: "03:45.78",
     isTimerPaused: true,
     isGameActive: false,
@@ -186,4 +174,5 @@ struct TimerCard: View {
     onToggleTimer: {}
   )
   .padding()
+  .modelContainer(try! PreviewGameData.createPreviewContainer(with: [PreviewGameData.completedGame]))
 }

--- a/PickleballGameTrackerPackage/Sources/GameTrackerFeature/Features/ActiveGame/Screens/ActiveGameView.swift
+++ b/PickleballGameTrackerPackage/Sources/GameTrackerFeature/Features/ActiveGame/Screens/ActiveGameView.swift
@@ -206,38 +206,44 @@ struct ActiveGameView: View {
   NavigationStack {
     ActiveGameView(
       game: PreviewGameData.earlyGame,
-      gameManager: SwiftDataGameManager(),
+      gameManager: PreviewGameData.gameManager,
       onDismiss: nil
     )
   }
+  .modelContainer(try! PreviewGameData.createPreviewContainer(with: [PreviewGameData.earlyGame]))
 }
 
 #Preview("Close Game") {
   NavigationStack {
     ActiveGameView(
       game: PreviewGameData.closeGame,
-      gameManager: SwiftDataGameManager(),
+      gameManager: PreviewGameData.gameManager,
       onDismiss: nil
     )
   }
+  .modelContainer(try! PreviewGameData.createPreviewContainer(with: [PreviewGameData.closeGame]))
 }
 
 #Preview("Initial Game") {
   NavigationStack {
     ActiveGameView(
       game: PreviewGameData.midGame,
-      gameManager: SwiftDataGameManager(),
+      gameManager: PreviewGameData.gameManager,
       onDismiss: nil
     )
   }
+  .modelContainer(try! PreviewGameData.createPreviewContainer(with: [PreviewGameData.midGame]))
 }
 
 #Preview("Completed Game") {
   NavigationStack {
     ActiveGameView(
       game: PreviewGameData.completedGame,
-      gameManager: SwiftDataGameManager(),
+      gameManager: PreviewGameData.gameManager,
       onDismiss: nil
     )
   }
+  .modelContainer(
+    try! PreviewGameData.createPreviewContainer(with: [PreviewGameData.completedGame])
+  )
 }


### PR DESCRIPTION
This implements the centralized SwiftUI preview provider.\n\n- Uses CorePackage  for scenarios and \n- Injects  in previews for SwiftData-backed views\n- Updates wiki  with guidance\n\nCloses #4