### PR TITLE
1.29: Design token sweep (iOS+watchOS)

### DIFF
--- a/PickleballGameTrackerPackage/Sources/GameTrackerFeature/Features/History/Components/GameHistoryCard.swift
+++ b/PickleballGameTrackerPackage/Sources/GameTrackerFeature/Features/History/Components/GameHistoryCard.swift
@@ -38,7 +38,7 @@ public struct GameHistoryCard: View {
         rightSideContent
         Image(systemName: "chevron.right")
           .font(.system(size: 16, weight: .semibold))
-          .foregroundColor(.white.opacity(0.6))
+          .foregroundColor(DesignSystem.Colors.textOnColorMuted)
           .shadow(color: .black.opacity(0.08), radius: 2, x: 0, y: 1)
           .padding(.leading, DesignSystem.Spacing.sm)
       }
@@ -66,13 +66,13 @@ public struct GameHistoryCard: View {
         Text(game.gameType.displayName)
           .font(DesignSystem.Typography.headline)
           .fontWeight(.bold)
-          .foregroundColor(.white)
+          .foregroundColor(DesignSystem.Colors.textOnColor)
           .lineLimit(1)
 
         Text(compactFormattedDate)
           .font(DesignSystem.Typography.caption)
           .fontWeight(.medium)
-          .foregroundColor(.white.opacity(0.85))
+          .foregroundColor(DesignSystem.Colors.textOnColorMuted)
           .lineLimit(1)
       }
     }
@@ -81,7 +81,7 @@ public struct GameHistoryCard: View {
   private var gameIcon: some View {
     Image(systemName: game.gameType.iconName)
       .font(.system(size: 24, weight: .medium))
-      .foregroundStyle(.white.gradient)
+      .foregroundStyle(DesignSystem.Colors.textOnColor)
       .shadow(color: .black.opacity(0.20), radius: 3, x: 0, y: 1)
       .frame(width: 32, height: 32)
   }
@@ -151,7 +151,7 @@ public struct GameHistoryCard: View {
       .font(DesignSystem.Typography.title1)
       .fontWeight(.bold)
       .fontDesign(.rounded)
-      .foregroundColor(isWinning ? .white : .white.opacity(0.7))
+      .foregroundColor(isWinning ? DesignSystem.Colors.textOnColor : DesignSystem.Colors.textOnColorMuted)
       .monospacedDigit()
       .shadow(color: .black.opacity(0.15), radius: 2, x: 0, y: 1)
       .frame(width: 45, alignment: .center)
@@ -184,14 +184,14 @@ public struct GameHistoryCard: View {
     HStack(spacing: DesignSystem.Spacing.xs) {
       Image(systemName: icon)
         .font(.system(size: 14, weight: .medium))
-        .foregroundColor(.white.opacity(0.8))
+        .foregroundColor(DesignSystem.Colors.textOnColorMuted)
         .frame(width: 16)
 
       Text(value)
         .font(DesignSystem.Typography.subheadline)
         .fontWeight(.semibold)
         .fontDesign(.rounded)
-        .foregroundColor(.white)
+        .foregroundColor(DesignSystem.Colors.textOnColor)
         .lineLimit(1)
     }
   }

--- a/PickleballGameTrackerPackage/Sources/GameTrackerFeature/UI/Components/GameOptionCard.swift
+++ b/PickleballGameTrackerPackage/Sources/GameTrackerFeature/UI/Components/GameOptionCard.swift
@@ -80,7 +80,7 @@ struct GameOptionCard: View {
           HStack(alignment: .center, spacing: DesignSystem.Spacing.md) {
             Image(systemName: gameType.iconName)
               .font(.system(size: iconLargeSize, weight: .medium))
-              .foregroundStyle(.white.gradient)
+              .foregroundStyle(DesignSystem.Colors.textOnColor)
               .shadow(
                 color: .black.opacity(0.20),
                 radius: 3,
@@ -92,14 +92,14 @@ struct GameOptionCard: View {
             Text(gameType.displayName)
               .font(DesignSystem.Typography.headline)
               .fontWeight(.bold)
-              .foregroundColor(.white)
+              .foregroundColor(DesignSystem.Colors.textOnColor)
               .multilineTextAlignment(.leading)
               .frame(maxWidth: .infinity, alignment: .leading)
           }
 
           Text(gameType.description)
             .font(DesignSystem.Typography.subheadline)
-            .foregroundColor(.white.opacity(0.9))
+            .foregroundColor(DesignSystem.Colors.textOnColorMuted)
             .multilineTextAlignment(.leading)
             .lineLimit(2)
             .frame(maxWidth: .infinity, alignment: .leading)
@@ -107,7 +107,7 @@ struct GameOptionCard: View {
 
         Image(systemName: "chevron.right")
           .font(.system(size: iconSmallSize, weight: .semibold))
-          .foregroundColor(.white.opacity(isInteractive ? 0.6 : 0.3))
+          .foregroundColor(DesignSystem.Colors.textOnColorMuted.opacity(isInteractive ? 0.75 : 0.4))
       }
       .padding(.bottom, headerBottomPadding)
 
@@ -164,19 +164,19 @@ private struct MetricColumn: View {
     VStack(spacing: DesignSystem.Spacing.xs) {
       Image(systemName: icon)
         .font(.system(size: iconSize, weight: .medium))
-        .foregroundColor(.white.opacity(0.8))
+        .foregroundColor(DesignSystem.Colors.textOnColorMuted)
         .shadow(color: .black.opacity(0.08), radius: 2, x: 0, y: 1)
 
       Text(label)
         .font(DesignSystem.Typography.caption)
         .fontWeight(.semibold)
-        .foregroundColor(.white.opacity(0.7))
+        .foregroundColor(DesignSystem.Colors.textOnColorMuted)
 
       Text(value)
         .font(DesignSystem.Typography.headline)
         .fontWeight(.bold)
         .fontDesign(.rounded)
-        .foregroundColor(.white)
+        .foregroundColor(DesignSystem.Colors.textOnColor)
         .monospacedDigit()
     }
     .frame(maxWidth: .infinity)

--- a/PickleballGameTrackerWatchPackage/Sources/GameTrackerWatchFeature/Features/GamesHome/Screens/WatchGameCatalogView.swift
+++ b/PickleballGameTrackerWatchPackage/Sources/GameTrackerWatchFeature/Features/GamesHome/Screens/WatchGameCatalogView.swift
@@ -62,7 +62,7 @@ public struct WatchGameCatalogView: View {
                 metadata: ["platform": "watchOS"])
             } label: {
               Image(systemName: "chart.bar.fill")
-                .foregroundColor(.white)
+                .foregroundColor(DesignSystem.Colors.textOnColor)
             }
           }
 
@@ -74,7 +74,7 @@ public struct WatchGameCatalogView: View {
                 metadata: ["platform": "watchOS"])
             } label: {
               Image(systemName: "clock")
-                .foregroundColor(.white)
+                .foregroundColor(DesignSystem.Colors.textOnColor)
             }
           }
 
@@ -91,12 +91,12 @@ public struct WatchGameCatalogView: View {
               if isCreatingGame {
                 ProgressView()
                   .progressViewStyle(
-                    CircularProgressViewStyle(tint: .white)
+                    CircularProgressViewStyle(tint: DesignSystem.Colors.textOnColor)
                   )
                   .scaleEffect(0.8)
               } else {
                 Image(systemName: "play.fill")
-                  .foregroundColor(.white)
+                  .foregroundColor(DesignSystem.Colors.textOnColor)
               }
             }
             .controlSize(.large)


### PR DESCRIPTION
Replace hardcoded colors/spacing with DesignSystem tokens across key components. iOS and watchOS targets build successfully.\n\n- iOS: GameOptionCard, GameHistoryCard\n- watchOS: WatchGameCatalogView toolbar/actions\n\nBuilds: iOS + watchOS ✅