### PR TITLE
Refactor TournamentBracketEngine and update GameType minimum player r…

### DIFF
--- a/PickleballGameTrackerCorePackage/Sources/GameTrackerCore/Application/Game/Tournament/TournamentBracketEngine.swift
+++ b/PickleballGameTrackerCorePackage/Sources/GameTrackerCore/Application/Game/Tournament/TournamentBracketEngine.swift
@@ -34,54 +34,52 @@ public struct TournamentBracketEngine: Sendable {
   private func firstRound(entries rawEntries: [UUID], useTeams: Bool, seeded: Bool) -> [ScheduledMatch] {
     guard rawEntries.count >= 2 else { return [] }
     
-    // Prepare entries: seeded keeps incoming order; otherwise shuffle
-    var entries = rawEntries
+    var entries: [UUID?] = rawEntries.map { $0 }
     if !seeded {
       entries.shuffle()
     }
     
-    // Expand to next power of two by adding implicit byes
+    // Expand to next power of two by adding explicit bye placeholders (nil)
     let target = nextPowerOfTwo(entries.count)
     let numByes = max(0, target - entries.count)
     if numByes > 0 {
-      // Standard seeding places byes against top seeds; we simulate by appending nils
-      entries.append(contentsOf: Array(repeating: UUID?.none, count: numByes).compactMap { $0 })
-      // Note: We cannot append nil to a [UUID]; instead we handle byes by pairing last entries unevenly.
-      // Fallback: while entries.count is odd, duplicate last to keep pairing, and the session manager can skip duplicates.
-      // But better approach: pair in a way to skip generating matches with missing opponents.
+      entries.append(contentsOf: Array(repeating: UUID?.none, count: numByes))
+      if !seeded {
+        entries.shuffle()
+      }
     }
     
-    // Pair up sequentially; if odd count, last gets a bye (no match generated)
+    // Pair up sequentially; skip generating a match when a bye is present
     var matches: [ScheduledMatch] = []
     var order = 0
     var i = 0
     while i < entries.count {
-      if i + 1 < entries.count {
-        let a = entries[i]
-        let b = entries[i + 1]
+      let a = entries[i]
+      let b = i + 1 < entries.count ? entries[i + 1] : nil
+      
+      if let aId = a, let bId = b {
         let match: ScheduledMatch
         if useTeams {
           match = ScheduledMatch(
             participantModeRaw: ParticipantMode.teams.rawValue,
-            side1TeamId: a,
-            side2TeamId: b,
+            side1TeamId: aId,
+            side2TeamId: bId,
             orderIndex: order
           )
         } else {
           match = ScheduledMatch(
             participantModeRaw: ParticipantMode.players.rawValue,
-            side1PlayerIds: [a],
-            side2PlayerIds: [b],
+            side1PlayerIds: [aId],
+            side2PlayerIds: [bId],
             orderIndex: order
           )
         }
         matches.append(match)
         order += 1
-        i += 2
-      } else {
-        // Bye: last entry advances; no match needed in first round
-        i += 1
       }
+      
+      // Bye: last entry advances; no match needed in first round
+      i += 2
     }
     return matches
   }

--- a/PickleballGameTrackerCorePackage/Sources/GameTrackerCore/Domain/Models/GameType.swift
+++ b/PickleballGameTrackerCorePackage/Sources/GameTrackerCore/Domain/Models/GameType.swift
@@ -265,7 +265,7 @@ public enum GameType: String, CaseIterable, Codable, Hashable, Sendable {
   /// Minimum total players supported for this game type (not per side)
   public var minPlayersTotal: Int {
     switch self {
-    case .cutthroat: return 2
+    case .cutthroat: return 3
     case .groupPlay: return 2
     default: return 2
     }


### PR DESCRIPTION
…equirement

- Updated the TournamentBracketEngine to handle bye placements more effectively and ensure matches are generated correctly.
- Changed the minimum total players required for the cutthroat game type from 2 to 3 to align with gameplay rules.

These changes improve the tournament logic and enhance game type definitions for better gameplay experience.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors the bracket engine to use explicit bye placeholders and only generate matches with two entrants, and updates cutthroat minimum players to 3.
> 
> - **Bracket Engine (`TournamentBracketEngine`)**:
>   - Represent entries as `UUID?` to insert explicit bye placeholders up to next power of two.
>   - For unseeded brackets, shuffle both before and after inserting byes.
>   - Pair sequentially and generate a `ScheduledMatch` only when both sides are non-nil (players or teams); skip bye matches.
> - **Game Type (`GameType`)**:
>   - Update `minPlayersTotal` for `cutthroat` from `2` to `3`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 90992b39c49c2ea3c28be024d9b2a6994d6d2dd0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->